### PR TITLE
Continue to additional surveys even if current survey cannot be found

### DIFF
--- a/tap_qualtrics/__init__.py
+++ b/tap_qualtrics/__init__.py
@@ -403,6 +403,7 @@ def sync_survey_responses(config, state, stream):
             except Qualtrics404Error:
                 # Continue to the next survey_id if the current survey is
                 # not found.
+                LOGGER.info('Received 404 from the API for survey_id %s', str(survey_id))
                 break
 
             with singer.metrics.record_counter(stream.tap_stream_id) as counter:

--- a/tap_qualtrics/exceptions.py
+++ b/tap_qualtrics/exceptions.py
@@ -26,6 +26,13 @@ class Qualtrics403Error(Exception):
         super().__init__(msg)
 
 
+class Qualtrics404Error(Exception):
+    """This Exception handles errors associated with the HTTP 404 (Not Found) responses."""
+
+    def __init__(self, msg):
+        super().__init__(msg)
+
+
 class Qualtrics429Error(Exception):
     """This Exception handles errors associated with the HTTP 429 (Too Many Requests) responses."""
 


### PR DESCRIPTION
JIRA: https://pathlighthq.atlassian.net/browse/FUJ-3475

One of the surveys is returning a 404 not found error but we have access to the other one. We should skip the survey that is erroring and continue to ingest, instead of stopping completely.

This could be due to the API user not having access to that particular survey.

https://community.qualtrics.com/XMcommunity/discussion/11805/404-survey-not-found-on-export-responses-call

```
CRITICAL {'requestId': '87ff721e-8bfe-47c9-8843-133f498a45ae', 'httpStatus': '404 - Not Found', 'error': {'errorCode': 'RTE_3', 'errorMessage': 'Survey not found'}}
```