### PR TITLE
Handle intermittent 500s from surveys_responses endpoint

### DIFF
--- a/tap_qualtrics/__init__.py
+++ b/tap_qualtrics/__init__.py
@@ -292,7 +292,14 @@ def get_survey_responses(survey_id, payload, config):
     download_url = url + is_file + '/file'
     headers = header_setup(headers, config)
     download_request = requests.get(download_url, headers=headers, stream=True)
-    if download_request.status_code >= 300:
+    if download_request.status_code == 500:
+        LOGGER.info('Internal server error downloading file', extra={
+            'survey_id': survey_id,
+            'download_url': download_url,
+            'error_message': download_request.text,
+        })
+        raise Qualtrics500Error(download_request.text)
+    elif download_request.status_code >= 300:
         raise Exception(download_request.text)
 
     with zipfile.ZipFile(io.BytesIO(download_request.content)) as survey_zip:
@@ -413,10 +420,10 @@ def sync_survey_responses(config, state, stream):
             }
             try:
                 records = get_survey_responses(survey_id, payload, config)
-            except Qualtrics404Error:
+            except (Qualtrics404Error, Qualtrics500Error) as e:
                 # Continue to the next survey_id if the current survey is
-                # not found.
-                LOGGER.info('Received 404 from the API for survey_id %s', str(survey_id))
+                # not found or an internal server error has occurred.
+                LOGGER.info('Cannot get responses - received %s error for survey ID %s', e.status_code, str(survey_id))
                 break
 
             with singer.metrics.record_counter(stream.tap_stream_id) as counter:

--- a/tap_qualtrics/__init__.py
+++ b/tap_qualtrics/__init__.py
@@ -293,11 +293,7 @@ def get_survey_responses(survey_id, payload, config):
     headers = header_setup(headers, config)
     download_request = requests.get(download_url, headers=headers, stream=True)
     if download_request.status_code == 500:
-        LOGGER.info('Internal server error downloading file', extra={
-            'survey_id': survey_id,
-            'download_url': download_url,
-            'error_message': download_request.text,
-        })
+        LOGGER.info('Internal server error downloading file for survey %s: %s', survey_id, download_url)
         raise Qualtrics500Error(download_request.text)
     elif download_request.status_code >= 300:
         raise Exception(download_request.text)
@@ -423,7 +419,7 @@ def sync_survey_responses(config, state, stream):
             except (Qualtrics404Error, Qualtrics500Error) as e:
                 # Continue to the next survey_id if the current survey is
                 # not found or an internal server error has occurred.
-                LOGGER.info('Cannot get responses - received %s error for survey ID %s', e.status_code, str(survey_id))
+                LOGGER.info('surveys_responses - received %s error for survey ID %s', e.status_code, str(survey_id))
                 break
 
             with singer.metrics.record_counter(stream.tap_stream_id) as counter:

--- a/tap_qualtrics/exceptions.py
+++ b/tap_qualtrics/exceptions.py
@@ -10,6 +10,7 @@ class Qualtrics400Error(Exception):
 
     def __init__(self, msg):
         super().__init__(msg)
+        self.status_code = 400
 
 
 class Qualtrics401Error(Exception):
@@ -17,6 +18,7 @@ class Qualtrics401Error(Exception):
 
     def __init__(self, msg):
         super().__init__(msg)
+        self.status_code = 401
 
 
 class Qualtrics403Error(Exception):
@@ -24,6 +26,7 @@ class Qualtrics403Error(Exception):
 
     def __init__(self, msg):
         super().__init__(msg)
+        self.status_code = 403
 
 
 class Qualtrics404Error(Exception):
@@ -31,6 +34,7 @@ class Qualtrics404Error(Exception):
 
     def __init__(self, msg):
         super().__init__(msg)
+        self.status_code = 404
 
 
 class Qualtrics429Error(Exception):
@@ -38,6 +42,7 @@ class Qualtrics429Error(Exception):
 
     def __init__(self, msg):
         super().__init__(msg)
+        self.status_code = 429
 
 
 class Qualtrics500Error(Exception):
@@ -45,6 +50,7 @@ class Qualtrics500Error(Exception):
 
     def __init__(self, msg):
         super().__init__(msg)
+        self.status_code = 500
 
 
 class Qualtrics503Error(Exception):
@@ -52,6 +58,7 @@ class Qualtrics503Error(Exception):
 
     def __init__(self, msg):
         super().__init__(msg)
+        self.status_code = 503
 
 
 class Qualtrics504Error(Exception):
@@ -59,3 +66,4 @@ class Qualtrics504Error(Exception):
 
     def __init__(self, msg):
         super().__init__(msg)
+        self.status_code = 504


### PR DESCRIPTION
JIRA: https://pathlighthq.atlassian.net/browse/FUJ-3506

Occasionally the download_url or API may return a 500, we should catch this exception and continue to the next survey_id rather than stopping the tap completely.

Tested by forcing an 500 exception:
```
INFO surveys_responses - received 500 error for survey ID [[SURVEY_ID]]
INFO Internal server error downloading file for survey [[SURVEY_ID]]: [[DOWNLOAD_URL]]
```