### PR TITLE
[BUG] Fix ticket.id and ticket.assignee.id type when parsing CSV

### DIFF
--- a/tap_qualtrics/__init__.py
+++ b/tap_qualtrics/__init__.py
@@ -302,6 +302,7 @@ def get_survey_responses(survey_id, payload, config):
         for s in survey_zip.infolist():
             # The CSV reader may sometimes interpret the ticket column IDs as numbers
             # instead of strings. We enforce the data types here.
+            # https://pathlighthq.atlassian.net/browse/FUJ-4912
             data_types = {'ticket.id':str,'ticket.assignee.id':str}
             df = pd.read_csv(survey_zip.open(s.filename), dtype=data_types)
             return df.to_dict('records')

--- a/tap_qualtrics/__init__.py
+++ b/tap_qualtrics/__init__.py
@@ -300,7 +300,10 @@ def get_survey_responses(survey_id, payload, config):
 
     with zipfile.ZipFile(io.BytesIO(download_request.content)) as survey_zip:
         for s in survey_zip.infolist():
-            df = pd.read_csv(survey_zip.open(s.filename))
+            # The CSV reader may sometimes interpret the ticket column IDs as numbers
+            # instead of strings. We enforce the data types here.
+            data_types = {'ticket.id':str,'ticket.assignee.id':str}
+            df = pd.read_csv(survey_zip.open(s.filename), dtype=data_types)
             return df.to_dict('records')
 
 


### PR DESCRIPTION
BUG: https://pathlighthq.atlassian.net/browse/FUJ-4912

We were not enforcing types when parsing the downloaded survey responses, so the CSV occasionally interpreted a column as a number instead of a string.

We fix this by enforcing the datatypes when using [pandas.read_csv](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html).

See the difference below in the output for `ticket.id` and `ticket.assignee.id`

---

BEFORE:
```
{
   "type":"RECORD",
   "stream":"surveys_responses",
   "record":{
      "start_date":"2023-05-31 16:57:58",
      "end_date":"2023-05-31 16:59:19",
      "status":"0",
      "ip_address":"31.94.11.33",
      "progress":"100",
      "duration":"81",
      "finished":"1",
      "recorded_date":"2023-05-31T16:59:20.000000Z",
      "response_id":"R_3KHF9X48bKw4hTo",
      "recipient_last_name":"Louisekflynn",
      "recipient_first_name":"Louisekflynn",
      "recipient_email":"louisekflynn@icloud.com",
      "external_reference":"nan",
      "location_latitude":"51.5074",
      "location_longitude":"-0.1196",
      "distribution_channel":"email",
      "user_language":"EN",
      "survey_id":"SV_8vNNbOjBS4InrcW",
      "other_properties":{
         "q2":"nan",
         "q2_6_text":"nan",
         "q4":"nan",
         "q5":"nan",
         "q5_5_text":"nan",
         "q3":"Although I was disappointed to have a problem being as the tread is only 2 months old, they came and fixed the problem the next day",
         "q6":"1.0",
         "ticket.assignee.email":"isaac.ward@onepeloton.com",
         "ticket.assignee.id":"4525692802708.0",
         "ticket.group.name":"UK Hardware Software",
         "ticket.id":"23889082.0",
         "ticket.via":"Chat",
         "ticket.status":"Solved",
         "numerical_csat":4.0
      }
   }
}
```

AFTER:
```
{
   "type":"RECORD",
   "stream":"surveys_responses",
   "record":{
      "start_date":"2023-05-31 16:57:58",
      "end_date":"2023-05-31 16:59:19",
      "status":"0",
      "ip_address":"31.94.11.33",
      "progress":"100",
      "duration":"81",
      "finished":"1",
      "recorded_date":"2023-05-31T16:59:20.000000Z",
      "response_id":"R_3KHF9X48bKw4hTo",
      "recipient_last_name":"Louisekflynn",
      "recipient_first_name":"Louisekflynn",
      "recipient_email":"louisekflynn@icloud.com",
      "external_reference":"nan",
      "location_latitude":"51.5074",
      "location_longitude":"-0.1196",
      "distribution_channel":"email",
      "user_language":"EN",
      "survey_id":"SV_8vNNbOjBS4InrcW",
      "other_properties":{
         "q2":"nan",
         "q2_6_text":"nan",
         "q4":"nan",
         "q5":"nan",
         "q5_5_text":"nan",
         "q3":"Although I was disappointed to have a problem being as the tread is only 2 months old, they came and fixed the problem the next day",
         "q6":"1.0",
         "ticket.assignee.email":"isaac.ward@onepeloton.com",
         "ticket.assignee.id":"4525692802708",
         "ticket.group.name":"UK Hardware Software",
         "ticket.id":"23889082",
         "ticket.via":"Chat",
         "ticket.status":"Solved",
         "numerical_csat":4.0
      }
   }
}
```